### PR TITLE
Extend trenzn

### DIFF
--- a/bayrischer_schmaaz.csv
+++ b/bayrischer_schmaaz.csv
@@ -333,7 +333,7 @@ sobbn,"langsam, schleichend gehen",
 soifen,sabbern,
 Suri,Rausch,
 tramhabbad,verträumt,
-trenzn,"weinen, schluchzen",
+trenzn,"weinen, schluchzen, oder etwas verschütten",Hosd di scho wida o'trenzd du Fagge!
 triadern,"verschütten, kleckern",
 "tridscheln, Tridschler","verschütten, pritscheln, aber auch unmotiviert, langsam agieren",
 üban Scheinkine lom,nichts über jemanden kommen lassen,


### PR DESCRIPTION
This PR extends the meaning of trenzn. 

Additionally a real-world example sentence including the word trenzn is included.